### PR TITLE
Fix GraphQL endpoint in GraphiQL (browser)

### DIFF
--- a/demo/public/sandbox/index.html
+++ b/demo/public/sandbox/index.html
@@ -37,16 +37,14 @@
 
     <script>
       const getGraphQLEndpoint = () => {
-        switch (process.env.NODE_ENV) {
-          case 'localgraphql':
-            // Run the demo against a local run graphql service in localhost
-            return 'http://localhost:8080/query'
-          case 'production':
-            // Run the demo from the netlify /graphql redirect
-            return '/graphql'
-          default:
+        if (window.location.hostname === 'localhost') {
+            // TODO: Figure out how to allow for running against the local graphql service
+            // return 'http://localhost:8080/query'
             // Anything else, assume local development against aws endpoint
             return 'http://ec2-3-133-13-197.us-east-2.compute.amazonaws.com:8080'
+        } else {
+            // Run the demo from the netlify /graphql redirect
+            return '/graphql'
         }
       }
       var url = '/'


### PR DESCRIPTION
Obviously, the browser JS can't read the nodeJS 'env' vars
so we will need to check the domain when deciding whether
to use he aws graphql endpoing or the netlify-proxy /graphql