### PR TITLE
Add intro content to the demo

### DIFF
--- a/demo/src/App.vue
+++ b/demo/src/App.vue
@@ -1,8 +1,7 @@
 <template>
   <v-app id="phoenix">
     <v-navigation-drawer v-model="drawer" app clipped dark color="accent">
-      <v-list subheader>
-        <v-subheader inset>Information</v-subheader>
+      <v-list subheader dense>
         <v-list-item link to="/">
           <v-list-item-action>
             <v-icon>fa-anchor</v-icon>
@@ -17,6 +16,14 @@
           </v-list-item-action>
           <v-list-item-content>
             <v-list-item-title>About</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+        <v-list-item link :href="sandboxLink">
+          <v-list-item-action>
+            <v-icon>fa-flask</v-icon>
+          </v-list-item-action>
+          <v-list-item-content>
+            <v-list-item-title>API sandbox</v-list-item-title>
           </v-list-item-content>
         </v-list-item>
 
@@ -35,16 +42,7 @@
             <v-icon>fa-file</v-icon>
           </v-list-item-action>
           <v-list-item-content>
-            <v-list-item-title>Wikidata keywords</v-list-item-title>
-          </v-list-item-content>
-        </v-list-item>
-        <v-subheader inset>GraphQL</v-subheader>
-        <v-list-item link :href="sandboxLink">
-          <v-list-item-action>
-            <v-icon>fa-file</v-icon>
-          </v-list-item-action>
-          <v-list-item-content>
-            <v-list-item-title>GraphQL Sandbox</v-list-item-title>
+            <v-list-item-title>Collections</v-list-item-title>
           </v-list-item-content>
         </v-list-item>
 

--- a/demo/src/views/About.vue
+++ b/demo/src/views/About.vue
@@ -19,10 +19,11 @@
         original articles.
       </p>
       <p>
-        Linking between sections and <a href="https://www.wikidata.org" target="_blank">Wikidata</a> topics
+        Linking between sections and keywords from <a href="https://www.wikidata.org" target="_blank">Wikidata</a>
         is provided by <a href="https://www.rosette.com/" target="_blank">Rosette</a>. Integration with Rosette
-        is intended to be a short-term feature for experimental use only. At this time, topics are not updated
-        when edits are made to the original content.
+        is intended to be a short-term feature for experimental use only. Phoenix is capable of updating keywords
+        in response to changes to the original content, but this feature is currently enabled for only a limited
+        set of content.
       </p>
       <p>
         This site connects to Phoenix using a GraphQL API. You can try out the API using the
@@ -53,11 +54,11 @@
     }
   }
 
-  # List sections related to a Wikidata topic
+  # List sections related to a Wikidata keyword
   {
-    nodes(relatedTo: "Q503") {
+    nodes(keyword: "Q503") {
       name
-      isPartOf
+      isPartOf { name }
       keywords {
         id
         salience

--- a/demo/src/views/About.vue
+++ b/demo/src/views/About.vue
@@ -1,17 +1,70 @@
 <template>
   <div class="about">
-    <h1 class="text-center">What is Phoenix?</h1>
-    <p>
-      <v-img
-        contain
-        alt="Vue logo"
-        src="../assets/phoenix.png"
-        max-height="300px"
-      />
-    </p>
-    <p>
-      Phoenix is a Proof of Value system, set to demonstrate the value of a
-      structured content on Wikipedia.
-    </p>
+    <v-container>
+      <h1>About Phoenix</h1>
+      <br>
+      <h2>What is Phoenix?</h2>
+      <p>
+        <a href="https://github.com/wikimedia/phoenix" target="_blank">Phoenix</a> is an experimental service
+        demonstrating the value of a structured content store. In addition to its functional capabilities,
+        Phoenix explores emerging architecture patterns that will direct modernization efforts at Wikimedia.
+        To learn more about Phoenix and the architecture process, read the
+        <a href="https://github.com/wikimedia/phoenix/blob/master/docs/artifact.md" target="_blank">artifact</a>.
+      </p>
+      <h2>How does it work?</h2>
+      <p>
+        Phoenix consumes a limited set of articles from
+        <a href="https://simple.wikipedia.org" target="_blank">Simple English Wikipedia</a>
+        and structures the content into sections. The content store is updated in response to changes to the
+        original articles.
+      </p>
+      <p>
+        Linking between sections and <a href="https://www.wikidata.org" target="_blank">Wikidata</a> topics
+        is provided by <a href="https://www.rosette.com/" target="_blank">Rosette</a>. Integration with Rosette
+        is intended to be a short-term feature for experimental use only. At this time, topics are not updated
+        when edits are made to the original content.
+      </p>
+      <p>
+        This site connects to Phoenix using a GraphQL API. You can try out the API using the
+        <a href="/sandbox">API sandbox</a>. To explore the schema, select <i>Docs</i> on the
+        right side of the sandbox.
+      </p>
+      <h3>Example queries</h3>
+      <pre
+        class="body-2"
+      >
+  # List sections in an article
+  {
+    page(name: { authority: "simple.wikipedia.org", name: "Banana"} ) {
+      name
+      dateModified
+      hasPart(offset: 0) {
+        name
+      }
+    }
+  }
+
+  # Request a specific section by name
+  {
+    node(name: { authority: "simple.wikipedia.org", pageName: "Banana", name: "Fruit" } ) {
+      dateModified
+      name
+      unsafe
+    }
+  }
+
+  # List sections related to a Wikidata topic
+  {
+    nodes(relatedTo: "Q503") {
+      name
+      isPartOf
+      keywords {
+        id
+        salience
+      }
+    }
+  }
+      </pre>
+    </v-container>
   </div>
 </template>

--- a/demo/src/views/Home.vue
+++ b/demo/src/views/Home.vue
@@ -9,14 +9,14 @@
       <p>
         <a href="https://github.com/wikimedia/phoenix" target="_blank">Phoenix</a> is an experimental
         service that consumes and structures Wikimedia content. It demonstrates how the information on
-        a wiki page can be stored as a set of parts. By associating parts with relevant topics, we can
+        a wiki page can be stored as a set of parts. By associating parts with relevant keywords, we can
         create relationships between pieces of knowledge across traditional page boundaries. This site
         lets you explore these relationships using content from
         <a href="https://simple.wikipedia.org" target="_blank">Simple English Wikipedia</a>
-        and topics from <a href="https://www.wikidata.org" target="_blank">Wikidata</a>.
+        and keywords from <a href="https://www.wikidata.org" target="_blank">Wikidata</a>.
       </p>
       <b>
-        Phoenix is intended for experimental purposes only. It is not a prototype or a production-ready system.
+        Phoenix is not a production-ready system.
         The API used in this demo should be considered unstable and may change without notice.
       </b>
       <br><br>
@@ -37,7 +37,7 @@
         </v-card>
         <v-spacer></v-spacer>
         <v-card>
-          <v-card-title>Explore collections by topic</v-card-title>
+          <v-card-title>Explore collections by keyword</v-card-title>
           <v-card-text>
             Make connections across pages by searching for sections related to Wikidata items.
           </v-card-text>

--- a/demo/src/views/Home.vue
+++ b/demo/src/views/Home.vue
@@ -28,7 +28,7 @@
           </v-card-text>
           <v-card-actions>
             <v-btn
-              href="/fetchbyname"
+              link to="/fetchbyname"
               text
             >
               Try it out
@@ -43,7 +43,7 @@
           </v-card-text>
           <v-card-actions>
             <v-btn
-              href="/fetchbykeyword"
+              link to="/fetchbykeyword"
               text
             >
               Try it out

--- a/demo/src/views/Home.vue
+++ b/demo/src/views/Home.vue
@@ -21,35 +21,38 @@
       </b>
       <br><br>
       <v-row>
-        <v-card>
-          <v-card-title>Get only the information you need</v-card-title>
-          <v-card-text>
-            Fetch just the part of a page that you need, without having to request the entire page.
-          </v-card-text>
-          <v-card-actions>
-            <v-btn
-              link to="/fetchbyname"
-              text
-            >
-              Try it out
-            </v-btn>
-          </v-card-actions>
-        </v-card>
-        <v-spacer></v-spacer>
-        <v-card>
-          <v-card-title>Explore collections by keyword</v-card-title>
-          <v-card-text>
-            Make connections across pages by searching for sections related to Wikidata items.
-          </v-card-text>
-          <v-card-actions>
-            <v-btn
-              link to="/fetchbykeyword"
-              text
-            >
-              Try it out
-            </v-btn>
-          </v-card-actions>
-        </v-card>
+        <v-col cols="12" md="6" lg="6" xl="6">
+          <v-card>
+            <v-card-title>Get only the information you need</v-card-title>
+            <v-card-text>
+              Fetch just the part of a page that you need, without having to request the entire page.
+            </v-card-text>
+            <v-card-actions>
+              <v-btn
+                link to="/fetchbyname"
+                text
+              >
+                Try it out
+              </v-btn>
+            </v-card-actions>
+          </v-card>
+        </v-col>
+        <v-col cols="12" md="6" lg="6" xl="6">
+          <v-card>
+            <v-card-title>Explore collections by keyword</v-card-title>
+            <v-card-text>
+              Make connections across pages by searching for sections related to Wikidata items.
+            </v-card-text>
+            <v-card-actions>
+              <v-btn
+                link to="/fetchbykeyword"
+                text
+              >
+                Try it out
+              </v-btn>
+            </v-card-actions>
+          </v-card>
+        </v-col>
       </v-row>
     </v-container>
   </div>

--- a/demo/src/views/Home.vue
+++ b/demo/src/views/Home.vue
@@ -1,7 +1,57 @@
 <template>
   <div class="home">
-    <v-img contain alt="Phoenix image" src="../assets/phoenix.png" max-height="300px" />
+    <v-img contain alt="Phoenix image" src="../assets/phoenix.png" max-height="150px" />
     <h1 class="text-center">Welcome to Phoenix</h1>
+    <p class="font-italic text-center">
+      Exploring emerging patterns for building systems that manage and distribute content
+    </p>
+    <v-container>
+      <p>
+        <a href="https://github.com/wikimedia/phoenix" target="_blank">Phoenix</a> is an experimental
+        service that consumes and structures Wikimedia content. It demonstrates how the information on
+        a wiki page can be stored as a set of parts. By associating parts with relevant topics, we can
+        create relationships between pieces of knowledge across traditional page boundaries. This site
+        lets you explore these relationships using content from
+        <a href="https://simple.wikipedia.org" target="_blank">Simple English Wikipedia</a>
+        and topics from <a href="https://www.wikidata.org" target="_blank">Wikidata</a>.
+      </p>
+      <b>
+        Phoenix is intended for experimental purposes only. It is not a prototype or a production-ready system.
+        The API used in this demo should be considered unstable and may change without notice.
+      </b>
+      <br><br>
+      <v-row>
+        <v-card>
+          <v-card-title>Get only the information you need</v-card-title>
+          <v-card-text>
+            Fetch just the part of a page that you need, without having to request the entire page.
+          </v-card-text>
+          <v-card-actions>
+            <v-btn
+              href="/fetchbyname"
+              text
+            >
+              Try it out
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+        <v-spacer></v-spacer>
+        <v-card>
+          <v-card-title>Explore collections by topic</v-card-title>
+          <v-card-text>
+            Make connections across pages by searching for sections related to Wikidata items.
+          </v-card-text>
+          <v-card-actions>
+            <v-btn
+              href="/fetchbykeyword"
+              text
+            >
+              Try it out
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-row>
+    </v-container>
   </div>
 </template>
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -4,14 +4,14 @@ This page defines important terms related to Phoenix.
 
 ### part/node
 A unit of knowledge smaller than a page, such as a section or a reference.
-A page is associated with one or more parts. A part is associated with one or more topics.
+A page is associated with one or more parts. A part is associated with one or more keywords.
 
-### topic/keyword
-A Wikidata item. A part is associated with one or more topics.
-Currently, Phoenix uses [Rosette](https://www.rosette.com/) to associate parts with topics.
+### keyword
+A Wikidata item. A part is associated with one or more keywords.
+Currently, Phoenix uses [Rosette](https://www.rosette.com/) to associate parts with keywords.
 
 ### collection
-A set of parts related by topic
+A set of parts related by keyword
 
 ### section
 Content grouped under a heading or as an introduction before the first heading on a page

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,20 @@
+# Glossary
+
+This page defines important terms related to Phoenix.
+
+### part/node
+A unit of knowledge smaller than a page, such as a section or a reference.
+A page is associated with one or more parts. A part is associated with one or more topics.
+
+### topic/keyword
+A Wikidata item. A part is associated with one or more topics.
+Currently, Phoenix uses [Rosette](https://www.rosette.com/) to associate parts with topics.
+
+### collection
+A set of parts related by topic
+
+### section
+Content grouped under a heading or as an introduction before the first heading on a page
+
+### authority
+The source of truth for the latest content, such as Simple English Wikipedia


### PR DESCRIPTION
Add intro content to the demo and discuss terminology for Phoenix in general. This PR:

- Organizes content in the demo into three pages:
  - Homepage: Brief intro and feature overview, including disclaimer about experimental status
  - About: High-level implementation explanation, link to artifact, and query examples to use in the sandbox
  - Sandbox: Moved up in the sidebar
- Introduces a glossary to /docs as a foundation for adding more descriptions to the schema

**Preview changes: https://deploy-preview-104--wikimediaphoenix.netlify.app/**