### PR TITLE
(IGNORE) service: rename `relatedTo` arg to `keyword`

### DIFF
--- a/demo/src/components/FormFetchKeyword.vue
+++ b/demo/src/components/FormFetchKeyword.vue
@@ -84,7 +84,7 @@ export default {
   methods: {
     fetchKeywordSections() {
       const query = `{
-  nodes(relatedTo: "${this.keyword}") {
+  nodes(keyword: "${this.keyword}") {
     name
     isPartOf
     unsafe

--- a/service/schema.gql
+++ b/service/schema.gql
@@ -5,7 +5,7 @@ schema {
 type Query {
   page(id: String, name: PageNameInput): Page
   node(id: String, name: NodeNameInput): Node
-  nodes(relatedTo: String): [Node]!
+  nodes(keyword: String): [Node]!
 }
 
 input PageNameInput {

--- a/service/service.go
+++ b/service/service.go
@@ -164,12 +164,12 @@ func (r *RootResolver) Node(args struct {
 }
 
 // Nodes returns relevant Nodes for a given predicate (currently only Wikidata topic ID)
-func (r *RootResolver) Nodes(args struct{ RelatedTo *string }) ([]*NodeResolver, error) {
+func (r *RootResolver) Nodes(args struct{ Keyword *string }) ([]*NodeResolver, error) {
 	var err error
 	var nodes []string
 	var resolvers = make([]*NodeResolver, 0)
 
-	if nodes, err = r.TopicSearch.Search(*args.RelatedTo); err != nil {
+	if nodes, err = r.TopicSearch.Search(*args.Keyword); err != nil {
 		return nil, fmt.Errorf("Topic search failed: %w", err)
 	}
 


### PR DESCRIPTION
This is a mistake (sorry) -- I was trying to update the PR, not push a new one. There doesn't seem to be  a way for me to delete this without opening it first.

Please ignore.