### PR TITLE
Resolve Wikidata items and allow flexible searches

### DIFF
--- a/demo/src/components/SectionBox.vue
+++ b/demo/src/components/SectionBox.vue
@@ -58,7 +58,7 @@ export default {
     },
     sectionDisplayName () {
       if (this.sectiondata.name === '__intro__') {
-        return `${this.pageTitle} (lead paragraph)`
+        return `${this.pageTitle} (introduction)`
       }
       return this.sectiondata.name.replaceAll('_', ' ')
     }

--- a/demo/src/components/SectionCollection.vue
+++ b/demo/src/components/SectionCollection.vue
@@ -6,7 +6,7 @@
         label
         large
         color="pink"
-        @click.stop="onSectionKeywordClicked(keyword)"
+        @click.stop="onKeywordInfoButtonClick(keyword)"
       >
         <v-avatar left>
           <v-icon>mdi-information</v-icon>
@@ -119,12 +119,16 @@ export default {
   },
   methods: {
     onSectionKeywordClicked(keyword) {
-      this.currWikidataItem = keyword
-      this.wikidataDialog = true
+      // Bubble up
+      this.$emit('keywordClick', keyword)
     },
     onPageInfoClicked(pageTitle) {
       this.viewPageTitle = pageTitle
       this.pageViewDialog = true
+    },
+    onKeywordInfoButtonClick(keyword) {
+      this.currWikidataItem = keyword
+      this.wikidataDialog = true
     }
   }
 }


### PR DESCRIPTION
Allow for clicking the wikidata keywords in sections so they now
are used as a search from the drop-down list.

Resolve the wikidata human-readable label.

Fixes #83
Fixes #84