### PR TITLE
Resolve all wikidata keywords with their labels

### DIFF
--- a/demo/src/components/SectionBox.vue
+++ b/demo/src/components/SectionBox.vue
@@ -26,7 +26,7 @@
         :key="k.id"
         @click.stop="onKeywordClick(k.id)"
       >
-        <v-icon small left>mdi-information</v-icon> {{k.id}} ({{percentSalience(k.salience)}})
+        <v-icon small left>mdi-information</v-icon> {{getKeywordLabel(k.id)}} ({{percentSalience(k.salience)}})
       </v-chip>
     </v-card-text>
   </v-card>
@@ -38,6 +38,7 @@ export default {
   props: {
     currKeyword: String,
     sectiondata: Object,
+    keywordLabels: Object,
     isPartOf: String
   },
   data: () => ({
@@ -64,6 +65,9 @@ export default {
     }
   },
   methods: {
+    getKeywordLabel(keyword) {
+      return this.keywordLabels[keyword] || keyword
+    },
     onKeywordClick(keyword) {
       this.$emit('keywordClick', keyword)
     },

--- a/demo/src/components/SectionCollection.vue
+++ b/demo/src/components/SectionCollection.vue
@@ -11,7 +11,7 @@
         <v-avatar left>
           <v-icon>mdi-information</v-icon>
         </v-avatar>
-        <strong>Keyword: {{keyword}}</strong>
+        <strong>Keyword: {{mainKeywordLabel}}</strong>
       </v-chip>
     <v-container>
       <masonry
@@ -23,6 +23,7 @@
           :key="sect.id"
           :sectiondata="sect"
           :currKeyword=keyword
+          :keywordLabels="keywordLabels"
           @keywordClick="onSectionKeywordClicked"
           @pageInfoClick="onPageInfoClicked"
         >
@@ -96,7 +97,8 @@ export default {
   components: { SectionBox },
   props: {
     keyword: String,
-    sections: Array
+    sections: Array,
+    keywordLabels: Object
   },
   data: () => ({
     wikidataDialog: false,
@@ -105,6 +107,12 @@ export default {
     viewPageTitle: null
   }),
   computed: {
+    mainKeywordLabel() {
+      if (this.keywordLabels[this.keyword]) {
+        return `${this.keyword} (${this.keywordLabels[this.keyword]})`
+      }
+      return this.keyword
+    },
     wikidataUrl() {
       console.log('sections', this.sections)
       return `https://www.wikidata.org/wiki/${this.keyword}`

--- a/demo/src/tools/WikidataFetcher.js
+++ b/demo/src/tools/WikidataFetcher.js
@@ -1,0 +1,110 @@
+import axios from 'axios'
+
+export default class WikidataFetcher {
+  constructor(lang = 'en', fallbackLang = 'en') {
+    this.cache = {}
+    this.lang = lang
+    this.fallbackLang = fallbackLang
+  }
+
+  fetchWikidataItemLabels (ids) {
+    ids = Array.isArray(ids) ? ids : [ids]
+    const filteredIDs = ids.filter(id => {
+      // Filter out empty ids, and ids we already have in cache
+      return !!id && !this.cache[id]
+    })
+    const promises = []
+
+    // Split the fetch IDs array since the API  limit is 50
+    this._splitArray(filteredIDs, 40)
+      .forEach(idArray => {
+        promises.push(this._getWikidataQueryForIDs(idArray))
+      })
+
+    return Promise.all(promises)
+      .then(values => {
+        const result = {}
+        // Merge all values in to one big object
+        let allValues = {}
+        values.forEach(v => {
+          if (!allValues.error) {
+            // skip errors from the API for now
+            allValues = { ...allValues, ...v }
+          }
+        })
+
+        // Clean up (transform from complex object to key->value of qID=>string)
+        // since it's all already in the requested language anyways
+        const cleanValues = {}
+        Object.keys(allValues).forEach(qID => {
+          cleanValues[qID] = (
+            // requested lang
+            (allValues[qID].labels[this.lang] && allValues[qID].labels[this.lang].value) ||
+            // fallback lang
+            (allValues[qID].labels[this.fallbackLang] && allValues[qID].labels[this.fallbackLang].value) ||
+            // qid
+            qID
+          )
+        })
+
+        // Store in cache
+        this.cache = { ...this.cache, ...cleanValues }
+
+        // Merge back with requested IDs from cache (that we removed above)
+        ids.forEach(requestedID => {
+          if (!requestedID) {
+            // skip empty values, just in case
+            return
+          }
+          result[requestedID] = this.cache[requestedID]
+        })
+
+        return result
+      })
+  }
+
+  // private
+  _getWikidataQueryForIDs(ids) {
+    return axios
+      .get(
+        'https://www.wikidata.org/w/api.php',
+        {
+          params: {
+            action: 'wbgetentities',
+            props: 'labels',
+            ids: ids.join('|'),
+            languages: this.lang + '|' + this.fallbackLang,
+            origin: '*',
+            format: 'json'
+          }
+        },
+        {
+          headers: {
+            'Content-Type': 'application/json; charset=UTF-8',
+            origin: '*'
+          }
+        }
+      )
+      .then(result => {
+        if (result.data.error) {
+          return Promise.reject(result.data.error)
+        }
+
+        return result.data.entities
+      })
+      .catch(error => {
+        console.log('error', error)
+        return {}
+      })
+  }
+
+  _splitArray(arr, chunkSize = 10) {
+    let i, j
+    const result = []
+    for (i = 0, j = arr.length; i < j; i += chunkSize) {
+      result.push(arr.slice(i, i + chunkSize))
+    }
+
+    return result
+  }
+}


### PR DESCRIPTION
Send a request (or series of requests, based on the 50-item limit)
to the wikidata API to resolve all keywords in displayed sections.
Cache the results so we only ask for keywords that are missing the
labels on new views.

Send that information down the component chain so we can use it
to display the human-readable label.