### PR TITLE
Intercept link clicks (transfer to wp in new tab) in pageInfo

### DIFF
--- a/demo/src/components/PageInfo.vue
+++ b/demo/src/components/PageInfo.vue
@@ -20,7 +20,7 @@
     max-width="80%"
     outlined
     >
-    <v-card-text v-html="pagedata.part.content"></v-card-text>
+    <v-card-text @click.stop="onContentClick" v-html="pagedata.part.content"></v-card-text>
     </v-card>
   </div>
 </template>
@@ -34,6 +34,23 @@ export default {
   computed: {
     humanReadable() {
       return moment(this.pagedata.modified).format('MMMM Do YYYY, h:mm:ss a')
+    }
+  },
+  methods: {
+    onContentClick(e) {
+      // HACK: We're getting internal links from the content; this is a bit of a
+      // cheat to get internal links to open in Simple English WP
+      if (e.target.tagName.toLowerCase() === 'a') {
+        let href = e.target.getAttribute('href')
+        if (e.target.getAttribute('rel') === 'mw:WikiLink') {
+          href = href.replace(/^(\.\/)/, '')
+          e.target.href = `http://simple.wikipedia.com/wiki/${href}`
+        }
+        // Change the target to open in new window
+        e.target.target = '_blank'
+
+        // Continue the link clicking...
+      }
     }
   }
   // data: () => ({})


### PR DESCRIPTION
The hack to intercept links from the content we're getting from
the sections was only implemented in the 'collections' section
this adds it to the PageInfo ('fetch part of a page') too